### PR TITLE
Trigger the scraper from a Github Action

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,0 +1,31 @@
+# for testing, trigger this on a pull request as well as cron.
+# TODO: delete the pull_request trigger.
+
+name: Scrape latest data
+
+on:
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron:  '* 3 * * *'
+
+jobs:
+  scheduled:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      with: ruby-version: 2.6
+    - name: Install dependencies
+      run: bundle install
+    - name: Run scraper
+      run: bundle exec ruby scraper.rb | tee data.csv
+    - name: Commit and push if it changed
+      run: |-
+        git config user.name "Automated"
+        git config user.email "actions@users.noreply.github.com"
+        git add -A
+        timestamp=$(date -u)
+        git commit -m "Latest data: ${timestamp}" || exit 0
+        git push


### PR DESCRIPTION
Every night, run the scraper, and update the repo with any changed data.

(For now this is also triggered on every pull-request, but that's just
to test that everything works. Once that's working, that part will be
removed)
